### PR TITLE
Fix problem with resize’s redirection

### DIFF
--- a/bin/nano
+++ b/bin/nano
@@ -12,6 +12,5 @@ else
 fi;
 
 clear;
-resize >/dev/null 2>&1;
+resize >/dev/null;
 TERMINFO=$dir/../etc/terminfo TERM=$term $dir/nano.bin "$@";
-


### PR DESCRIPTION
When I start `nano` using the script in this repo, the screen is cleared and then I have to press enter before the editor actually starts. I figured out that it was a problem with `resize`, since when I remove the stderr redirection, the problem goes away. The `resize` program I’m using is the from the most recent `busybox` module made by you. Do you have another idea to fix this, and what could be causing this?